### PR TITLE
Message wrapping now avoids splitting words

### DIFF
--- a/design.css
+++ b/design.css
@@ -357,6 +357,7 @@ body span.message{
 	min-height: 22px;
 	line-height: 22px;
 	width: calc(100% - 250px);
+	word-break: normal;
 }
 
 body div.event + div.event {


### PR DESCRIPTION
The changes of 4ceea2f0f77a4cd9f140998213fd4b60b7fbae31 truncate every single word that approaches the end of the line. This doesn't really look good, and hinders readability.

This makes messages use `word-break: normal`, which attempts to avoid breaking words, but will break if a word doesn't fit on its own line. This is the default behavior in modern browsers
