### PR TITLE
More compact line height

### DIFF
--- a/design.css
+++ b/design.css
@@ -167,7 +167,7 @@ div[id=mark] {
 	z-index: 295;
 	margin-top: -1px;
 	border-bottom: 1px solid;
-	border-color: #444;
+	border-color: #999;
 	-webkit-transition: 0.2s linear;
 }
 


### PR DESCRIPTION
The line height as used by Whisper was significantly larger than it used to be. This breaks readability, especially in busier channels. This pull-request sets a more pleasant line height. See also commit 36bf55dcd2e6c8222ddd33a5e3bb4bae6b2cbcdc that introduced this change.

Additionally, it slightly takes the dark edge off the 'mark', that has become quite dark in contrast.
