### PR TITLE
Add nick coalescence for multiple lines.

### DIFF
--- a/design.css
+++ b/design.css
@@ -5,7 +5,7 @@
 	padding: 0;
 	font-size: 100%;
 	word-wrap: break-word;
-}	
+}
 
 body {
 	color: #000;
@@ -35,7 +35,7 @@ body {
 }
 
 body .line {
- 	border-bottom:1px solid #efefef;
+ 	border-top:1px solid #efefef;
 }
 
 body[dir=rtl] .sender {
@@ -50,7 +50,7 @@ body[dir=rtl] .sender {
 /* Loading Screen */
 
 #loading_screen {
-	position:absolute; 
+	position:absolute;
 	top: 50%;
 	left: 50%;
 	margin-top: -11px;
@@ -143,7 +143,7 @@ a:hover {
 	white-space: normal;
 }
 
-#topic_bar a, 
+#topic_bar a,
 #topic_bar .channel {
 }
 
@@ -173,7 +173,7 @@ div[id=mark] {
 
 /* Historic Line */
 
-.historic 
+.historic
 {
 	opacity: 0.6;
 }
@@ -237,7 +237,7 @@ body div[ltype*=privmsg][mtype*=myself] .message {
 body div[ltype*=privmsg] .sender {
 	font-weight: 700;
 	width:134px;
-	text-shadow: #fff 0px 1px; 
+	text-shadow: #fff 0px 1px;
 	background-color: #eee;
 	min-height:30px;
 	border-right: 1px solid #dcdcdc;
@@ -273,7 +273,7 @@ body div[ltype*=action] .sender {
 	left: 0;
 	font-weight: 700;
 	width:134px;
-	text-shadow: #fff 0px 1px; 
+	text-shadow: #fff 0px 1px;
 	background-color: #eee;
 	height:30px;
 	padding-right:5px;
@@ -328,7 +328,7 @@ body div.line[ltype*=rawhtml] {
 
 /* Message of the Day (MOTD) */
 /* 720, 721, 722 are used by ShadowIRCd for Oper MOTD. */
-/* 372, 375, 376 are normal MOTD shared by several IRCds. */ 
+/* 372, 375, 376 are normal MOTD shared by several IRCds. */
 
 body div.line[command="372"],
 body div.line[command="721"] {
@@ -353,7 +353,7 @@ body div.line[command="722"] { /* End. */
 
 body div.line[command="372"] .message,
 body div.line[command="375"] .message,
-body div.line[command="376"] .message 
+body div.line[command="376"] .message
 body div.line[command="720"] .message,
 body div.line[command="721"] .message,
 body div.line[command="722"] .message {
@@ -443,194 +443,194 @@ body .inline_nickname {
 	color: #000;
 }
 
-body div[ltype*=privmsg] .sender[ltype*=myself], 
-body div[ltype*=privmsg] .sender[mtype*=myself] { 
-	color: #7ae; 
+body div[ltype*=privmsg] .sender[ltype*=myself],
+body div[ltype*=privmsg] .sender[mtype*=myself] {
+	color: #7ae;
 }
 
-body .sender[ltype*=normal][colornumber='0'], 
-body .sender[mtype*=normal][colornumber='0'], 
+body .sender[ltype*=normal][colornumber='0'],
+body .sender[mtype*=normal][colornumber='0'],
 body .inline_nickname[colornumber='0'] {
-	color: #008; 
+	color: #008;
 }
 
-body .sender[ltype*=normal][colornumber='1'], 
-body .sender[mtype*=normal][colornumber='1'], 
+body .sender[ltype*=normal][colornumber='1'],
+body .sender[mtype*=normal][colornumber='1'],
 body .inline_nickname[colornumber='1'] {
-	color: #333; 
+	color: #333;
 }
 
-body .sender[ltype*=normal][colornumber='2'], 
-body .sender[mtype*=normal][colornumber='2'], 
+body .sender[ltype*=normal][colornumber='2'],
+body .sender[mtype*=normal][colornumber='2'],
 body .inline_nickname[colornumber='2'] {
-	color: #66a; 
+	color: #66a;
 }
 
-body .sender[ltype*=normal][colornumber='3'], 
-body .sender[mtype*=normal][colornumber='3'], 
+body .sender[ltype*=normal][colornumber='3'],
+body .sender[mtype*=normal][colornumber='3'],
 body .inline_nickname[colornumber='3'] {
-	color: #458; 
+	color: #458;
 }
 
-body .sender[ltype*=normal][colornumber='4'], 
-body .sender[mtype*=normal][colornumber='4'], 
+body .sender[ltype*=normal][colornumber='4'],
+body .sender[mtype*=normal][colornumber='4'],
 body .inline_nickname[colornumber='4'] {
-	color: #080; 
+	color: #080;
 }
 
-body .sender[ltype*=normal][colornumber='5'], 
-body .sender[mtype*=normal][colornumber='5'], 
+body .sender[ltype*=normal][colornumber='5'],
+body .sender[mtype*=normal][colornumber='5'],
 body .inline_nickname[colornumber='5'] {
-	color: #a32; 
+	color: #a32;
 }
 
-body .sender[ltype*=normal][colornumber='6'], 
-body .sender[mtype*=normal][colornumber='6'], 
+body .sender[ltype*=normal][colornumber='6'],
+body .sender[mtype*=normal][colornumber='6'],
 body .inline_nickname[colornumber='6'] {
-	color: #820; 
+	color: #820;
 }
 
-body .sender[ltype*=normal][colornumber='7'], 
-body .sender[mtype*=normal][colornumber='7'], 
+body .sender[ltype*=normal][colornumber='7'],
+body .sender[mtype*=normal][colornumber='7'],
 body .inline_nickname[colornumber='7'] {
-	color: #808; 
+	color: #808;
 }
 
-body .sender[ltype*=normal][colornumber='8'], 
-body .sender[mtype*=normal][colornumber='8'], 
+body .sender[ltype*=normal][colornumber='8'],
+body .sender[mtype*=normal][colornumber='8'],
 body .inline_nickname[colornumber='8'] {
-	color: #f80; 
+	color: #f80;
 }
 
-body .sender[ltype*=normal][colornumber='9'], 
-body .sender[mtype*=normal][colornumber='9'], 
+body .sender[ltype*=normal][colornumber='9'],
+body .sender[mtype*=normal][colornumber='9'],
 body .inline_nickname[colornumber='9'] {
-	color: #ac5; 
+	color: #ac5;
 }
 
-body .sender[ltype*=normal][colornumber='10'], 
-body .sender[mtype*=normal][colornumber='10'], 
+body .sender[ltype*=normal][colornumber='10'],
+body .sender[mtype*=normal][colornumber='10'],
 body .inline_nickname[colornumber='10'] {
-	color: #00CC52; 
+	color: #00CC52;
 }
 
-body .sender[ltype*=normal][colornumber='11'], 
-body .sender[mtype*=normal][colornumber='11'], 
+body .sender[ltype*=normal][colornumber='11'],
+body .sender[mtype*=normal][colornumber='11'],
 body .inline_nickname[colornumber='11'] {
-	color: #088; 
+	color: #088;
 }
 
-body .sender[ltype*=normal][colornumber='12'], 
-body .sender[mtype*=normal][colornumber='12'], 
+body .sender[ltype*=normal][colornumber='12'],
+body .sender[mtype*=normal][colornumber='12'],
 body .inline_nickname[colornumber='12'] {
-	color: #a1f; 
+	color: #a1f;
 }
 
-body .sender[ltype*=normal][colornumber='13'], 
-body .sender[mtype*=normal][colornumber='13'], 
+body .sender[ltype*=normal][colornumber='13'],
+body .sender[mtype*=normal][colornumber='13'],
 body .inline_nickname[colornumber='13'] {
-	color: #cc6; 
+	color: #cc6;
 }
 
-body .sender[ltype*=normal][colornumber='14'], 
-body .sender[mtype*=normal][colornumber='14'], 
+body .sender[ltype*=normal][colornumber='14'],
+body .sender[mtype*=normal][colornumber='14'],
 body .inline_nickname[colornumber='14'] {
-	color: #d8f; 
+	color: #d8f;
 }
 
-body .sender[ltype*=normal][colornumber='15'], 
-body .sender[mtype*=normal][colornumber='15'], 
+body .sender[ltype*=normal][colornumber='15'],
+body .sender[mtype*=normal][colornumber='15'],
 body .inline_nickname[colornumber='15'] {
-	color: #888; 
+	color: #888;
 }
 
-body .sender[ltype*=normal][colornumber='16'], 
-body .sender[mtype*=normal][colornumber='16'], 
-body .inline_nickname[colornumber='16'] { 
+body .sender[ltype*=normal][colornumber='16'],
+body .sender[mtype*=normal][colornumber='16'],
+body .inline_nickname[colornumber='16'] {
 	color: #c66;
 }
 
-body .sender[ltype*=normal][colornumber='17'], 
-body .sender[mtype*=normal][colornumber='17'], 
-body .inline_nickname[colornumber='17'] { 
+body .sender[ltype*=normal][colornumber='17'],
+body .sender[mtype*=normal][colornumber='17'],
+body .inline_nickname[colornumber='17'] {
 	color: #b41;
 }
 
-body .sender[ltype*=normal][colornumber='18'], 
-body .sender[mtype*=normal][colornumber='18'], 
-body .inline_nickname[colornumber='18'] { 
+body .sender[ltype*=normal][colornumber='18'],
+body .sender[mtype*=normal][colornumber='18'],
+body .inline_nickname[colornumber='18'] {
 	color: #aa0;
 }
 
-body .sender[ltype*=normal][colornumber='19'], 
-body .sender[mtype*=normal][colornumber='19'], 
-body .inline_nickname[colornumber='19'] { 
+body .sender[ltype*=normal][colornumber='19'],
+body .sender[mtype*=normal][colornumber='19'],
+body .inline_nickname[colornumber='19'] {
 	color: #6df;
 }
 
-body .sender[ltype*=normal][colornumber='20'], 
-body .sender[mtype*=normal][colornumber='20'], 
-body .inline_nickname[colornumber='20'] { 
+body .sender[ltype*=normal][colornumber='20'],
+body .sender[mtype*=normal][colornumber='20'],
+body .inline_nickname[colornumber='20'] {
 	color: #7f4;
 }
 
-body .sender[ltype*=normal][colornumber='21'], 
-body .sender[mtype*=normal][colornumber='21'], 
-body .inline_nickname[colornumber='21'] { 
+body .sender[ltype*=normal][colornumber='21'],
+body .sender[mtype*=normal][colornumber='21'],
+body .inline_nickname[colornumber='21'] {
 	color: #665;
 }
 
-body .sender[ltype*=normal][colornumber='22'], 
-body .sender[mtype*=normal][colornumber='22'], 
-body .inline_nickname[colornumber='22'] { 
+body .sender[ltype*=normal][colornumber='22'],
+body .sender[mtype*=normal][colornumber='22'],
+body .inline_nickname[colornumber='22'] {
 	color: #b13637;
 }
 
-body .sender[ltype*=normal][colornumber='23'], 
-body .sender[mtype*=normal][colornumber='23'], 
-body .inline_nickname[colornumber='23'] { 
+body .sender[ltype*=normal][colornumber='23'],
+body .sender[mtype*=normal][colornumber='23'],
+body .inline_nickname[colornumber='23'] {
 	color: #e45d59;
 }
 
-body .sender[ltype*=normal][colornumber='24'], 
-body .sender[mtype*=normal][colornumber='24'], 
-body .inline_nickname[colornumber='24'] { 
+body .sender[ltype*=normal][colornumber='24'],
+body .sender[mtype*=normal][colornumber='24'],
+body .inline_nickname[colornumber='24'] {
 	color: #1b51ae;
 }
 
-body .sender[ltype*=normal][colornumber='25'], 
-body .sender[mtype*=normal][colornumber='25'], 
-body .inline_nickname[colornumber='25'] { 
+body .sender[ltype*=normal][colornumber='25'],
+body .sender[mtype*=normal][colornumber='25'],
+body .inline_nickname[colornumber='25'] {
 	color: #4855ac;
 }
 
-body .sender[ltype*=normal][colornumber='20'], 
-body .sender[mtype*=normal][colornumber='20'], 
-body .inline_nickname[colornumber='20'] { 
+body .sender[ltype*=normal][colornumber='20'],
+body .sender[mtype*=normal][colornumber='20'],
+body .inline_nickname[colornumber='20'] {
 	color: #7f1d86;
 }
 
-body .sender[ltype*=normal][colornumber='27'], 
-body .sender[mtype*=normal][colornumber='27'], 
-body .inline_nickname[colornumber='27'] { 
+body .sender[ltype*=normal][colornumber='27'],
+body .sender[mtype*=normal][colornumber='27'],
+body .inline_nickname[colornumber='27'] {
 	color: #73643f;
 }
 
-body .sender[ltype*=normal][colornumber='28'], 
-body .sender[mtype*=normal][colornumber='28'], 
-body .inline_nickname[colornumber='28'] { 
+body .sender[ltype*=normal][colornumber='28'],
+body .sender[mtype*=normal][colornumber='28'],
+body .inline_nickname[colornumber='28'] {
 	color: #0b9578;
 }
 
-body .sender[ltype*=normal][colornumber='29'], 
-body .sender[mtype*=normal][colornumber='29'], 
-body .inline_nickname[colornumber='29'] { 
+body .sender[ltype*=normal][colornumber='29'],
+body .sender[mtype*=normal][colornumber='29'],
+body .inline_nickname[colornumber='29'] {
 	color: #569c96;
 }
 
-body .sender[ltype*=normal][colornumber='30'], 
-body .sender[mtype*=normal][colornumber='30'], 
-body .inline_nickname[colornumber='30'] { 
+body .sender[ltype*=normal][colornumber='30'],
+body .sender[mtype*=normal][colornumber='30'],
+body .inline_nickname[colornumber='30'] {
 	color: #08465f;
 }
 

--- a/scripts.js
+++ b/scripts.js
@@ -1,15 +1,70 @@
 /* Defined in: "Textual.app -> Contents -> Resources -> JavaScript -> API -> core.js" */
 
+Whisper = {
+	getLine: function(lineNum) {
+		return document.getElementById('line-' + lineNum);
+	},
+
+	getSender: function(line) {
+		if (line) {
+			return line.querySelector('.sender');
+		} else {
+			return null;
+		}
+	},
+
+	getSenderNick: function(sender) {
+		if (sender) { return sender.getAttribute('nickname'); }
+	},
+
+	getPreviousLine: function(line) {
+		var prevLine = line.previousElementSibling;
+		if (prevLine && prevLine.classList && prevLine.classList.contains('line')) {
+			return prevLine;
+		}
+	},
+
+	getLineType: function(line) {
+		return line ? line.getAttribute('ltype') : null;
+	},
+
+	coalesceLines: function(lineNum) {
+		var line = Whisper.getLine(lineNum);
+		var prevLine = Whisper.getPreviousLine(line);
+
+		var sender = Whisper.getSender(line);
+		var prevSender = Whisper.getSender(prevLine);
+
+		var senderNick = Whisper.getSenderNick(sender);
+		var prevSenderNick = Whisper.getSenderNick(prevSender);
+
+		var type = Whisper.getLineType(line);
+		var prevType = Whisper.getLineType(line);
+
+
+		if (!sender || !prevSender ) { return; }
+
+		if (senderNick === prevSenderNick && type === 'privmsg' && prevType === 'privmsg') {
+			line.classList.add('coalesced');
+			sender.innerHTML = '';
+		}
+	}
+};
+
 Textual.viewFinishedLoading = function()
 {
 	Textual.fadeInLoadingScreen(1.00, 0.95);
-	
+
 	setTimeout(function() {
-		Textual.scrollToBottomOfView()
+		Textual.scrollToBottomOfView();
 	}, 500);
-}
+};
 
 Textual.viewFinishedReload = function()
 {
 	Textual.viewFinishedLoading();
-}
+};
+
+Textual.newMessagePostedToView = function (lineNum) {
+	Whisper.coalesceLines(lineNum);
+};


### PR DESCRIPTION
This isn't exactly inline with the original way whisper worked, and if you reject it because of that, I understand.

Basically, when a single user sends multiple lines, this hides their nick (and the divider lines) from successive messages.

![screen shot 2014-10-23 at 3 33 02 pm](https://cloud.githubusercontent.com/assets/168193/4762641/be428796-5b04-11e4-857e-b1395513e8d7.png)

This is how hipchat and several other "modern" chat applications work, and it leads to a less busy UI.
