### PR TITLE
Fix the occasional scroll-bar that appears on images

### DIFF
--- a/design.css
+++ b/design.css
@@ -635,7 +635,7 @@ body .inline_nickname[colornumber='30'] {
 }
 
 .inlineImageCell {
-	overflow: auto;
+	overflow: hidden;
 	display: block;
 	margin-top: 15px;
 	margin-bottom: 12px;


### PR DESCRIPTION
Occasionally, some images would get a small scrollbar, when displayed inline. This sets the image container to hide overflow, in effect, preventing the scrollbar from appearing.

I checked it with tall images too, and it doesn't seem to cause problems
