### PR TITLE
Style tweaks and fixes for image close button

### DIFF
--- a/design.css
+++ b/design.css
@@ -657,16 +657,16 @@ body .inline_nickname[colornumber='30'] {
 	cursor: pointer;
 	border-radius: 5px;
 	color: #fff;
-	line-height: 14px;
+	line-height: 13px;
 	font-size: 20px;
 	width: 20px;
-	height: 15px;
-	text-indent: 4.5px;
+	height: 20px;
 	font-weight: 900;
 	background-color:#bcbcbc;
 	background:-webkit-gradient(linear, left top, left bottom, from(#d1d1d1), to(#bcbcbc));
 	padding-top:2px;
-	float:left;
+	float:right;
+	text-align: center;
 
 }
 


### PR DESCRIPTION
Fixes #9

Adjust the sizing and padding of the image close buttons

Also moves it over to the right side, like how it appears in Linkinius

![screen shot 2014-10-24 at 11 49 04 am](https://cloud.githubusercontent.com/assets/168193/4774671/7e41e3b6-5baf-11e4-9c4d-5ed68c7aa86f.png)
