### PR TITLE
Add highlight around inline nicknames

### DIFF
--- a/design.css
+++ b/design.css
@@ -441,6 +441,12 @@ body div.event span.message[ltype*=mode]{
 
 body .inline_nickname {
 	color: #000;
+	display: inline-block;
+	line-height: 1;
+	padding: 4px 2px;
+	background: hsl(0,0%,96%);
+	border: 1px solid hsl(0,0%,90%);
+	border-radius: 3px;
 }
 
 body div[ltype*=privmsg] .sender[ltype*=myself],


### PR DESCRIPTION
Just something I was playing around with.

This makes inline nicks look a lot more like they do in Hipchat and other "rich" chat interfaces, by, specifically, giving them a border and light background.

![image](https://cloud.githubusercontent.com/assets/168193/4775004/4f864b26-5bb3-11e4-8116-b8c9ebc66a2e.png)
