### PR TITLE
Fix close button spacing and positioning

### DIFF
--- a/design.css
+++ b/design.css
@@ -657,16 +657,16 @@ body .inline_nickname[colornumber='30'] {
 	cursor: pointer;
 	border-radius: 5px;
 	color: #fff;
-	line-height: 14px;
+	line-height: 13px;
 	font-size: 20px;
 	width: 20px;
-	height: 15px;
-	text-indent: 4.5px;
+	height: 20px;
 	font-weight: 900;
 	background-color:#bcbcbc;
 	background:-webkit-gradient(linear, left top, left bottom, from(#d1d1d1), to(#bcbcbc));
 	padding-top:2px;
-	float:left;
+	float:right;
+	text-align: center;
 
 }
 


### PR DESCRIPTION
Fixes #9

This also moves the image close button over to the _right_ of the image, as in Linkinius.

![screen shot 2014-10-24 at 11 49 04 am](https://cloud.githubusercontent.com/assets/168193/4775043/c0ec2c04-5bb3-11e4-80e7-3f4da2f2a327.png)
