### PR TITLE
Prevent phantom scrollbar from appearing on inline images

### DIFF
--- a/design.css
+++ b/design.css
@@ -635,7 +635,7 @@ body .inline_nickname[colornumber='30'] {
 }
 
 .inlineImageCell {
-	overflow: auto;
+	overflow: hidden;
 	display: block;
 	margin-top: 15px;
 	margin-bottom: 12px;


### PR DESCRIPTION
Sometimes, inline images get a tiny, useless scrollbar, that does nothing other than look bad.

This gets rid of it

I tested with a very long image too, and it worked fine
