### PR TITLE
Replace float with flexbox

### DIFF
--- a/design.css
+++ b/design.css
@@ -642,7 +642,7 @@ body .inline_nickname[colornumber='30'] {
 
 .inlineImageCell {
 	overflow: hidden;
-	display: block;
+	display: -webkit-flex;
 	margin-top: 15px;
 	margin-bottom: 12px;
 }
@@ -657,6 +657,7 @@ body .inline_nickname[colornumber='30'] {
 	background:-webkit-gradient(linear, left top, left bottom, from(#d1d1d1), to(#bcbcbc));
 	padding:10px;
 	border-radius: 5px;
+	-webkit-order: 1;
 }
 
 .inlineImageCell .closeButton {
@@ -671,8 +672,8 @@ body .inline_nickname[colornumber='30'] {
 	background-color:#bcbcbc;
 	background:-webkit-gradient(linear, left top, left bottom, from(#d1d1d1), to(#bcbcbc));
 	padding-top:2px;
-	float:right;
 	text-align: center;
+	-webkit-order: 2;
 
 }
 


### PR DESCRIPTION
Inline images are a little odd, in that they take up the entire width of their container. Floating the close right worked for short lines, but for long lines, it would appear way off to the side.

Switching to flexbox allows us to reorder the image and the close button, and solves this issue
