### PR TITLE
Bugfix to the sender componenent that made it scrollable when a nickname...

### DIFF
--- a/design.css
+++ b/design.css
@@ -244,7 +244,7 @@ body div[ltype*=privmsg] .sender {
 	padding-right:5px;
 	text-align:right;
 	display:inline-block;
-	overflow: auto;
+	overflow: hidden;
 	position: absolute;
 	top: 0;
 	bottom: 0;


### PR DESCRIPTION
... was longer than the container's width. The nickname maintained its ellipses when it was too long.
